### PR TITLE
Make amm compatible with legacy-bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "array-init"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,6 +38,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a5720225ef5daecf08657f23791354e1685a8c91a4c60c7f3d3b2892f978f4"
+checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
 dependencies = [
  "crypto-mac",
  "digest",
@@ -143,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.5"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
 ]
@@ -229,6 +226,12 @@ dependencies = [
  "cfg-if",
  "lazy_static",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-mac"
@@ -340,6 +343,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac",
+ "digest",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
+dependencies = [
+ "digest",
+ "generic-array",
+ "hmac",
+]
+
+[[package]]
 name = "impl-serde"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,16 +385,18 @@ dependencies = [
 
 [[package]]
 name = "ink_allocator"
-version = "3.0.0-rc4"
-source = "git+https://github.com/paritytech/ink/?rev=45ef413#45ef4132d05088171173934cd1b00cc6ad5237c1"
+version = "3.0.0-rc7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "178faaaf06ce9b39561e74c6dfd52f95ec10eab6802506f51871ad909ed78a9d"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "ink_env"
-version = "3.0.0-rc4"
-source = "git+https://github.com/paritytech/ink/?rev=45ef413#45ef4132d05088171173934cd1b00cc6ad5237c1"
+version = "3.0.0-rc7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d4e24e4e502b3ccb5a17c63939c62685afc86c111e608e67d00c7315491e3"
 dependencies = [
  "arrayref",
  "blake2",
@@ -380,6 +406,7 @@ dependencies = [
  "ink_metadata",
  "ink_prelude",
  "ink_primitives",
+ "libsecp256k1",
  "num-traits",
  "parity-scale-codec",
  "paste",
@@ -387,30 +414,41 @@ dependencies = [
  "scale-info",
  "sha2",
  "sha3",
- "sp-arithmetic",
  "static_assertions",
 ]
 
 [[package]]
+name = "ink_eth_compatibility"
+version = "3.0.0-rc7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ae645f0d2ceab1ee6d1795d7edf7c73b40f4d14a96a81013eb93ce08d03d30"
+dependencies = [
+ "ink_env",
+ "libsecp256k1",
+]
+
+[[package]]
 name = "ink_lang"
-version = "3.0.0-rc4"
-source = "git+https://github.com/paritytech/ink/?rev=45ef413#45ef4132d05088171173934cd1b00cc6ad5237c1"
+version = "3.0.0-rc7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a14f4d647a1fa8f8eedbfbeb30da402511cb7ebcddc941c5a884b947bb18ff29"
 dependencies = [
  "derive_more",
  "ink_env",
+ "ink_eth_compatibility",
  "ink_lang_macro",
  "ink_metadata",
  "ink_prelude",
  "ink_primitives",
  "ink_storage",
  "parity-scale-codec",
- "static_assertions",
 ]
 
 [[package]]
 name = "ink_lang_codegen"
-version = "3.0.0-rc4"
-source = "git+https://github.com/paritytech/ink/?rev=45ef413#45ef4132d05088171173934cd1b00cc6ad5237c1"
+version = "3.0.0-rc7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37a75f82cf745d3f5eaed608bf9dd8164691cf7a1b191ffeae6b60604d95a422"
 dependencies = [
  "blake2",
  "derive_more",
@@ -422,28 +460,28 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "regex",
  "syn",
 ]
 
 [[package]]
 name = "ink_lang_ir"
-version = "3.0.0-rc4"
-source = "git+https://github.com/paritytech/ink/?rev=45ef413#45ef4132d05088171173934cd1b00cc6ad5237c1"
+version = "3.0.0-rc7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ed4bdfe35ecec0866a372d1281c09a8078a8c4fa8fe12bc1e1deec78733b881"
 dependencies = [
  "blake2",
  "either",
  "itertools",
  "proc-macro2",
  "quote",
- "regex",
  "syn",
 ]
 
 [[package]]
 name = "ink_lang_macro"
-version = "3.0.0-rc4"
-source = "git+https://github.com/paritytech/ink/?rev=45ef413#45ef4132d05088171173934cd1b00cc6ad5237c1"
+version = "3.0.0-rc7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96903239c56c164e5f528c0a54be7fb6b29a4a90b7a3aee7312cfab153df4ad4"
 dependencies = [
  "ink_lang_codegen",
  "ink_lang_ir",
@@ -455,8 +493,9 @@ dependencies = [
 
 [[package]]
 name = "ink_metadata"
-version = "3.0.0-rc4"
-source = "git+https://github.com/paritytech/ink/?rev=45ef413#45ef4132d05088171173934cd1b00cc6ad5237c1"
+version = "3.0.0-rc7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2034307ba808bb48c4690ccde20c132477320e0e34ce026e3261086f98080852"
 dependencies = [
  "derive_more",
  "impl-serde",
@@ -468,17 +507,20 @@ dependencies = [
 
 [[package]]
 name = "ink_prelude"
-version = "3.0.0-rc4"
-source = "git+https://github.com/paritytech/ink/?rev=45ef413#45ef4132d05088171173934cd1b00cc6ad5237c1"
+version = "3.0.0-rc7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1dcc2e722bfcf4ced2ec8d76cef9a63c738fb8481ac48405dbdf17c1784f83"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "ink_primitives"
-version = "3.0.0-rc4"
-source = "git+https://github.com/paritytech/ink/?rev=45ef413#45ef4132d05088171173934cd1b00cc6ad5237c1"
+version = "3.0.0-rc7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca6a17d2fa825b17f5d5a84529b7edcfa2b09034b97d5026790c76e811523f4"
 dependencies = [
+ "cfg-if",
  "ink_prelude",
  "parity-scale-codec",
  "scale-info",
@@ -486,8 +528,9 @@ dependencies = [
 
 [[package]]
 name = "ink_storage"
-version = "3.0.0-rc4"
-source = "git+https://github.com/paritytech/ink/?rev=45ef413#45ef4132d05088171173934cd1b00cc6ad5237c1"
+version = "3.0.0-rc7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17e038ee1d4203ed4915fa5a809ec5c660be76846231f0e64eebf90ff8c723a"
 dependencies = [
  "array-init",
  "cfg-if",
@@ -504,22 +547,14 @@ dependencies = [
 
 [[package]]
 name = "ink_storage_derive"
-version = "3.0.0-rc4"
-source = "git+https://github.com/paritytech/ink/?rev=45ef413#45ef4132d05088171173934cd1b00cc6ad5237c1"
+version = "3.0.0-rc7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf027da2c5597dc1c2a551eab24f9df0817c62956b16bdbecbf4b89904685a2"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "integer-sqrt"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -560,9 +595,57 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.99"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+
+[[package]]
+name = "libsecp256k1"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0452aac8bab02242429380e9b2f94ea20cea2b37e2c1777a1358799bbe97f37"
+dependencies = [
+ "arrayref",
+ "base64",
+ "digest",
+ "hmac-drbg",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand",
+ "serde",
+ "sha2",
+ "typenum",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
+dependencies = [
+ "crunchy",
+ "digest",
+ "subtle",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
+dependencies = [
+ "libsecp256k1-core",
+]
 
 [[package]]
 name = "log"
@@ -631,9 +714,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8975095a2a03bbbdc70a74ab11a4f76a6d0b84680d87c68d722531b0ac28e8a9"
+checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -645,11 +728,11 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40dbbfef7f0a1143c5b06e0d76a6278e25dac0bc1af4be51a0fbb73f07e7ad09"
+checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
- "proc-macro-crate 1.0.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -709,15 +792,6 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
-
-[[package]]
-name = "proc-macro-crate"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-dependencies = [
- "toml",
-]
 
 [[package]]
 name = "proc-macro-crate"
@@ -824,8 +898,6 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax",
 ]
 
@@ -867,10 +939,11 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "0.6.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd819984fe6ce661ebed1f451c0848d301a05ff56b8a4b0ae420de7dca046ea"
+checksum = "5c55b744399c25532d63a0d2789b109df8d46fc93752d46b0782991a931a782f"
 dependencies = [
+ "bitvec",
  "cfg-if",
  "derive_more",
  "parity-scale-codec",
@@ -880,11 +953,11 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "0.4.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e321c3d4ef7d3a90b0b4eda276d4215c6cbf3d59f66a9934e7866a48dcaa29b3"
+checksum = "baeb2780690380592f86205aa4ee49815feb2acad8c2f59e6dd207148c3f1fcd"
 dependencies = [
- "proc-macro-crate 0.1.5",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -945,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.5"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer",
  "cfg-if",
@@ -967,36 +1040,6 @@ dependencies = [
  "keccak",
  "opaque-debug",
 ]
-
-[[package]]
-name = "sp-arithmetic"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f1c69966c192d1dee8521f0b29ece2b14db07b9b44d801a94e295234761645"
-dependencies = [
- "integer-sqrt",
- "num-traits",
- "parity-scale-codec",
- "sp-debug-derive",
- "sp-std",
-]
-
-[[package]]
-name = "sp-debug-derive"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e80275f23b4e7ba8f54dec5f90f016530e7307d2ee9445f617ab986cbe97f31e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "sp-std"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35391ea974fa5ee869cb094d5b437688fbf3d8127d64d1b9fed5822a1ed39b12"
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,43 +1,52 @@
 [package]
-name = "pendulum_amm"
-version = "0.1.0"
 authors = ["[your_name] <[your_email]>"]
 edition = "2018"
+name = "pendulum_amm"
+resolver = "2"
+version = "0.1.0"
 
+# Needed until https://github.com/paritytech/ink/issues/364 is resolved.
 [profile.release]
 overflow-checks = false
 
 [dependencies]
-ink_primitives = { git = "https://github.com/paritytech/ink/", rev = "45ef413", default-features = false }
-ink_metadata = { git = "https://github.com/paritytech/ink/", rev = "45ef413", default-features = false, features = ["derive"], optional = true }
-ink_env = { git = "https://github.com/paritytech/ink/", rev = "45ef413", default-features = false }
-ink_storage = { git = "https://github.com/paritytech/ink/", rev = "45ef413", default-features = false }
-ink_lang = { git = "https://github.com/paritytech/ink/", rev = "45ef413", default-features = false }
-ink_prelude = { git = "https://github.com/paritytech/ink/", rev = "45ef413", default-features = false }
+ink_env = {version = "=3.0.0-rc7", default-features = false}
+ink_lang = {version = "=3.0.0-rc7", default-features = false}
+ink_metadata = {version = "=3.0.0-rc7", default-features = false, features = ["derive"], optional = true}
+ink_prelude = {version = "=3.0.0-rc7", default-features = false}
+ink_primitives = {version = "=3.0.0-rc7", default-features = false}
+ink_storage = {version = "=3.0.0-rc7", default-features = false}
 
-scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
-scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
+scale = {package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"]}
+scale-info = {version = "1.0.0", default-features = false, features = ["derive"], optional = true}
 
-num-integer = { version = "0.1.36", default-features = false }
+num-integer = {version = "0.1.44", default-features = false}
+
+[patch."https://github.com/paritytech/ink/"]
+ink_allocator = {version = "=3.0.0-rc7"}
+ink_lang_codegen = {version = "=3.0.0-rc7"}
+ink_lang_ir = {version = "=3.0.0-rc7"}
+ink_storage_derive = {version = "=3.0.0-rc7"}
 
 [lib]
+crate-type = [
+  # Used for normal contract Wasm blobs.
+  "cdylib",
+]
 name = "pendulum_amm"
 path = "src/lib.rs"
-crate-type = [
-	# Used for normal contract Wasm blobs.
-	"cdylib",
-]
 
 [features]
 default = ["std"]
-std = [
-    "ink_primitives/std",
-    "ink_metadata/std",
-    "ink_env/std",
-    "ink_storage/std",
-    "ink_lang/std",
-    "scale/std",
-    "scale-info",
-    "scale-info/std",
-]
 ink-as-dependency = []
+std = [
+  "ink_primitives/std",
+  "ink_metadata/std",
+  "ink_prelude/std",
+  "ink_env/std",
+  "ink_storage/std",
+  "ink_lang/std",
+  "scale/std",
+  "scale-info/std",
+  "num-integer/std",
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,6 @@ impl Environment for CustomEnvironment {
     type Hash = <ink_env::DefaultEnvironment as Environment>::Hash;
     type BlockNumber = <ink_env::DefaultEnvironment as Environment>::BlockNumber;
     type Timestamp = <ink_env::DefaultEnvironment as Environment>::Timestamp;
-    type RentFraction = <ink_env::DefaultEnvironment as Environment>::RentFraction;
 
     type ChainExtension = BalanceExtension;
 }


### PR DESCRIPTION
These changes make the smart contract compatible with the pendulum [legacy-bridge](https://github.com/pendulum-chain/pendulum/tree/legacy-bridge) (or to be more precise make it compatible with the substrate modules of version [v0.9.13 ](https://github.com/paritytech/substrate/tree/polkadot-v0.9.13) that the legacy-bridge is using).

The dependencies are now declared with an equal sign (`"=3.0.0-rc7"`) to make sure that exactly this version is used for ink! crates. Otherwise, the latest compatible release would be used which is `"3.0.0-rc8"`, which in fact is incompatible with the pallet-contracts version that we are using (as is stated in the release notes [here](https://github.com/paritytech/ink/releases/tag/v3.0.0-rc8)). 

The `[patch."https://github.com/paritytech/ink/"]` is required to make sure that the other ink! crates that are used as peer dependencies are also using version `"3.0.0-rc7"`. Declaring them directly under the dependency section would cause duplicate naming errors.

Side note: [`cargo-contract`](https://github.com/paritytech/cargo-contract) v16 was used for compiling the contract but it should also work with other versions. 