### PR TITLE
31 serde for std only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4330,7 +4330,6 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "serde_json",
  "sp-core",
  "sp-io",
  "sp-runtime",

--- a/pallet/Cargo.toml
+++ b/pallet/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2021"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-serde = { version = "1.0.119", default-feature = false, features = ["derive"] }
-serde_json = { version = '1.0.45', default-features = false, features = ['alloc'] }
+serde = { version = "1.0.119", default-feature = false, features = ["derive"], optional = true }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
     "derive",
 ] }
@@ -37,7 +36,8 @@ std = [
     "frame-benchmarking/std",
     "pallet-timestamp/std",
     "sp-runtime/std",
-    "sp-std/std"
+    "sp-std/std",
+    "serde"
 ]
 
 runtime-benchmarks = ["frame-benchmarking/runtime-benchmarks", "pallet-timestamp/runtime-benchmarks"]


### PR DESCRIPTION
to fix https://github.com/pendulum-chain/pendulum/issues/31 

plugging this pallet to the [pendulum](https://github.com/pendulum-chain/pendulum) caused an error:
```
  error: duplicate lang item in crate `sp_io` (which `substrate_stellar_sdk` depends on): `panic_impl`.
    |
    = note: the lang item is first defined in crate `std` (which `serde` depends on)
    = note: first definition in `std` loaded from /home/jitterbug/.rustup/toolchains/nightly-2021-12-12-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-unknown/lib/libstd-10bfc64443a2c69d.rlib
    = note: second definition in `sp_io` loaded from /pendulum/target/release/wbuild/pendulum-parachain-runtime/target/wasm32-unknown-unknown/release/deps/libsp_io-69fbc6428aed0d63.rmeta

  error: duplicate lang item in crate `sp_io` (which `substrate_stellar_sdk` depends on): `oom`.
    |
    = note: the lang item is first defined in crate `std` (which `serde` depends on)
    = note: first definition in `std` loaded from .rustup/toolchains/nightly-2021-12-12-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-unknown/lib/libstd-10bfc64443a2c69d.rlib
    = note: second definition in `sp_io` loaded from /pendulum/target/release/wbuild/pendulum-parachain-runtime/target/wasm32-unknown-unknown/release/deps/libsp_io-69fbc6428aed0d63.rmeta
```
apparently the serde_json and serde are stds (?) 